### PR TITLE
refactor: dbShutdown and add event handlers for it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,0 @@
-- Refactor dbShutdown and add event handlers for it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Refactor dbShutdown and add event handlers for it.

--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,7 @@ machine:
     MONGO_TEST_CONNECTION_STRING: mongodb://localhost:27017/dummy-test
 
   node:
-    version: "8.1.4"
+    version: "8.4.0"
 
   timezone: America/Los_Angeles
 

--- a/config/index.js
+++ b/config/index.js
@@ -52,15 +52,19 @@ const initConnection = (opts = {}) => {
   dbConnection = mongoose.connection
   dbConnection.on('error', handleErr)
   dbConnection.on('open', () => { resolveConnection(dbConnection) })
+  dbConnection.on('disconnecting', () => logger.info('disconnecting mongodb...'))
+  dbConnection.on('disconnected', () => logger.info('mongodb connection successfully disconnected.'))
 }
 
-const dbShutdown = cb => {
+const dbShutdown = async cb => {
   logger.info('Shutting down db connection')
   // This may be a sudden termination and not wait for all saves to finish
-  dbConnection.close(err => {
+  try {
+    await dbConnection.close()
+  } catch (err) {
     logger.error(err)
     mongoose.disconnect(cb)
-  })
+  }
 }
 
 module.exports = {

--- a/config/index.js
+++ b/config/index.js
@@ -52,12 +52,11 @@ const initConnection = async (opts = {}) => {
   dbConnection = mongoose.connection
   dbConnection.on('error', handleErr)
   dbConnection.on('open', () => { resolveConnection(dbConnection) })
-  dbConnection.on('disconnecting', () => logger.info('disconnecting mongodb...'))
+  dbConnection.on('disconnecting', () => logger.info('shutting down db connection'))
   dbConnection.on('disconnected', () => logger.info('mongodb connection successfully disconnected.'))
 }
 
 const dbShutdown = async () => {
-  logger.info('Shutting down db connection')
   // This may be a sudden termination and not wait for all saves to finish
   try {
     await dbConnection.close()

--- a/config/index.js
+++ b/config/index.js
@@ -40,7 +40,7 @@ const defaultOptions = {
 const assignMongooseOptions = opts => Object.assign(defaultOptions, opts)
 
 let initialized = false
-const initConnection = (opts = {}) => {
+const initConnection = async (opts = {}) => {
   const mongodbUri = (process.env.NODE_ENV === 'test')
     ? process.env.MONGO_TEST_CONNECTION_STRING
     : process.env.MONGO_CONNECTION_STRING
@@ -48,7 +48,7 @@ const initConnection = (opts = {}) => {
   if (initialized) return
   initialized = true
   const mongooseOptions = assignMongooseOptions(opts)
-  mongoose.connect(mongodbUri, mongooseOptions)
+  await mongoose.connect(mongodbUri, mongooseOptions)
   dbConnection = mongoose.connection
   dbConnection.on('error', handleErr)
   dbConnection.on('open', () => { resolveConnection(dbConnection) })
@@ -56,14 +56,13 @@ const initConnection = (opts = {}) => {
   dbConnection.on('disconnected', () => logger.info('mongodb connection successfully disconnected.'))
 }
 
-const dbShutdown = async cb => {
+const dbShutdown = async () => {
   logger.info('Shutting down db connection')
   // This may be a sudden termination and not wait for all saves to finish
   try {
     await dbConnection.close()
   } catch (err) {
     logger.error(err)
-    mongoose.disconnect(cb)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "description": "",
   "engines": {
-    "node": "^8.1.4"
+    "node": "^8.4.0"
   },
   "homepage": "https://github.com/invisible-tech/mongoose-extras#readme",
   "author": {


### PR DESCRIPTION
This PR refactor dbShutdown to use async await and add event handlers when the connection is disconnecting and when it was successfully disconnected.