### PR TITLE
Refact: use internal instance of mongoose and export it

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -13,8 +13,8 @@ machine:
     NODE_ENV: test
     PORT: 3000
 
-    MONGO_CONNECTION_STRING: mongodb://localhost:27017/dummy
-    MONGO_TEST_CONNECTION_STRING: mongodb://localhost:27017/dummy-test
+    DB_CONNECTION_STRING: mongodb://localhost:27017/dummy
+    DB_TEST_CONNECTION_STRING: mongodb://localhost:27017/dummy-test
 
   node:
     version: "8.4.0"

--- a/config/index.js
+++ b/config/index.js
@@ -56,7 +56,7 @@ const initConnection = (mongodbUri, opts = {}) => {
 const dbShutdown = async () => {
   // This may be a sudden termination and not wait for all saves to finish
   try {
-    await dbConnection.close()
+    await dbConnection().close()
   } catch (err) {
     logger.error(err)
   }

--- a/config/index.js
+++ b/config/index.js
@@ -40,20 +40,17 @@ const defaultOptions = {
 const assignMongooseOptions = opts => Object.assign(defaultOptions, opts)
 
 let initialized = false
-const initConnection = async (opts = {}) => {
-  const mongodbUri = (process.env.NODE_ENV === 'test')
-    ? process.env.MONGO_TEST_CONNECTION_STRING
-    : process.env.MONGO_CONNECTION_STRING
+const initConnection = (mongodbUri, opts = {}) => {
   if (! mongodbUri) throw new Error(`mongodbUri '${mongodbUri}' is invalid`)
   if (initialized) return
   initialized = true
   const mongooseOptions = assignMongooseOptions(opts)
-  await mongoose.connect(mongodbUri, mongooseOptions)
-  dbConnection = mongoose.connection
-  dbConnection.on('error', handleErr)
-  dbConnection.on('open', () => { resolveConnection(dbConnection) })
-  dbConnection.on('disconnecting', () => logger.info('shutting down db connection'))
-  dbConnection.on('disconnected', () => logger.info('mongodb connection successfully disconnected.'))
+  mongoose.connect(mongodbUri, mongooseOptions)
+  dbConnection = () => mongoose.connection
+  dbConnection().on('error', handleErr)
+  dbConnection().on('open', () => { resolveConnection(dbConnection) })
+  dbConnection().on('disconnecting', () => logger.info('shutting down db connection'))
+  dbConnection().on('disconnected', () => logger.info('mongodb connection successfully disconnected.'))
 }
 
 const dbShutdown = async () => {

--- a/config/index.js
+++ b/config/index.js
@@ -1,5 +1,7 @@
 'use strict'
 
+/* eslint-disable no-console */
+
 const mongoose = require('mongoose')
 const {
   flow,
@@ -7,15 +9,13 @@ const {
   startsWith,
 } = require('lodash/fp')
 
-const logger = require('@invisible/logger')
-
 // use native promises
 mongoose.Promise = global.Promise
 
 const handleErr = err => {
   const isConnRefused = flow(get('message'), startsWith('connect ECONNREFUSED'))
   if (isConnRefused(err)) throw err
-  else logger.error(err)
+  else console.log(`ERROR: ${err}`)
 }
 
 let resolveConnection // eslint-disable-line one-var
@@ -46,8 +46,8 @@ const initConnection = (mongodbUri, opts = {}) => {
   mongoose.connect(mongodbUri, mongooseOptions)
   mongoose.connection.on('error', handleErr)
   mongoose.connection.on('open', () => { resolveConnection(mongoose.connection) })
-  mongoose.connection.on('disconnecting', () => logger.info('shutting down db connection'))
-  mongoose.connection.on('disconnected', () => logger.info('mongodb connection successfully disconnected.'))
+  mongoose.connection.on('disconnecting', () => console.log('INFO: shutting down db connection'))
+  mongoose.connection.on('disconnected', () => console.log('INFO: mongodb connection successfully disconnected.'))
 }
 
 const dbShutdown = async () => {
@@ -55,7 +55,7 @@ const dbShutdown = async () => {
   try {
     await mongoose.connection.close()
   } catch (err) {
-    logger.error(err)
+    console.log(`ERROR: ${err}`)
   }
 }
 

--- a/customAsserts/documentAssertions.js
+++ b/customAsserts/documentAssertions.js
@@ -12,7 +12,7 @@ const {
   sortBy,
 } = require('lodash/fp')
 
-const { isObjectId } = require('../index.js')
+const { isObjectId } = require('../helpers/mongooseHelper.js')
 
 const prettyJson = obj => JSON.stringify(obj, null, 2)
 const isDefined = negate(isUndefined)

--- a/env.sample
+++ b/env.sample
@@ -1,5 +1,5 @@
 
 # Mongoose connection samples for .env file
-MONGO_CONNECTION_STRING=mongodb://localhost:27017/dummy
-MONGO_TEST_CONNECTION_STRING=mongodb://localhost:27017/dummy-test
+DB_CONNECTION_STRING=mongodb://localhost:27017/dummy
+DB_TEST_CONNECTION_STRING=mongodb://localhost:27017/dummy-test
 PORT=3000

--- a/index.js
+++ b/index.js
@@ -33,7 +33,6 @@ const {
 } = require('./helpers/mongooseHelper.js')
 
 const {
-  dbConnection,
   dbShutdown,
   getConnection,
   initConnection,
@@ -54,7 +53,6 @@ module.exports = {
   assertThrows,
   clearCollections,
   clearIndexes,
-  dbConnection,
   dbShutdown,
   getConnection,
   getId,

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const mongoose = require('mongoose')
+
 const {
   assertNotSameObjectId,
   assertSameDocument,
@@ -7,6 +9,7 @@ const {
   assertSameDocumentIdArray,
   assertSameObjectId,
   assertSameObjectIdArray,
+  assertThrows,
 } = require('./customAsserts/documentAssertions.js')
 
 const {
@@ -34,7 +37,7 @@ const {
   dbShutdown,
   getConnection,
   initConnection,
-} = require('./config')
+} = require('./config/index.js')
 
 module.exports = {
   addIndexes,
@@ -48,6 +51,7 @@ module.exports = {
   assertSameObjectId,
   assertSameObjectIdArray,
   assertInstance,
+  assertThrows,
   clearCollections,
   clearIndexes,
   dbConnection,
@@ -59,6 +63,7 @@ module.exports = {
   initConnection,
   isObjectId,
   isSameObjectId,
+  mongoose,
   pickIds,
   upsertModel,
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@invisible/mongoose-extras",
+  "name": "@invisible/mongoose",
   "license": "MIT",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "engines": {
     "node": "^8.4.0"
@@ -23,7 +23,7 @@
     "@invisible/logger": "^0.0.3",
     "common-tags": "^1.4.0",
     "lodash": "^4.17.4",
-    "mongoose": "^4.11.5",
+    "mongoose": "^4.11.11",
     "mongoose-unique-validator": "^1.0.5",
     "retry": "^0.10.1"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "test": "NODE_ENV=test nyc mocha $(find test -name '*.spec.js')"
   },
   "dependencies": {
-    "@invisible/logger": "^0.0.3",
     "common-tags": "^1.4.0",
     "lodash": "^4.17.4",
     "mongoose": "^4.11.11",

--- a/test/customAsserts/documentAssertions.spec.js
+++ b/test/customAsserts/documentAssertions.spec.js
@@ -2,6 +2,7 @@
 
 const assert = require('assert')
 const mongoose = require('mongoose')
+
 const {
   assertNotSameObjectId,
   assertSameDocument,

--- a/test/helpers/mongooseHelper.spec.js
+++ b/test/helpers/mongooseHelper.spec.js
@@ -2,7 +2,6 @@
 
 const assert = require('assert')
 const mongoose = require('mongoose')
-
 const {
   forEach,
   get,
@@ -20,7 +19,7 @@ const {
   isObjectId,
   isSameObjectId,
   upsertModel,
-} = require('../../helpers/mongooseHelper')
+} = require('../../helpers/mongooseHelper.js')
 
 const { Schema } = mongoose
 const { ObjectId } = mongoose.Types

--- a/yarn.lock
+++ b/yarn.lock
@@ -1949,19 +1949,19 @@ moment@^2.18.1:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
 
-mongodb-core@2.1.11:
-  version "2.1.11"
-  resolved "https://registry.yarnpkg.com/mongodb-core/-/mongodb-core-2.1.11.tgz#1c38776ceb174997a99c28860eed9028da9b3e1a"
+mongodb-core@2.1.15:
+  version "2.1.15"
+  resolved "https://registry.yarnpkg.com/mongodb-core/-/mongodb-core-2.1.15.tgz#841f53b87ffff4c7458189c35c8ae827e1169764"
   dependencies:
     bson "~1.0.4"
     require_optional "~1.0.0"
 
-mongodb@2.2.27:
-  version "2.2.27"
-  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-2.2.27.tgz#34122034db66d983bcf6ab5adb26a24a70fef6e6"
+mongodb@2.2.31:
+  version "2.2.31"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-2.2.31.tgz#1940445c661e19217bb3bf8245d9854aaef548db"
   dependencies:
     es6-promise "3.2.1"
-    mongodb-core "2.1.11"
+    mongodb-core "2.1.15"
     readable-stream "2.2.7"
 
 mongoose-unique-validator@^1.0.5:
@@ -1971,15 +1971,15 @@ mongoose-unique-validator@^1.0.5:
     lodash.foreach "^4.1.0"
     lodash.get "^4.0.2"
 
-mongoose@^4.11.5:
-  version "4.11.5"
-  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-4.11.5.tgz#59e4a1d84dcd36cc51f3e639b771cb8359f539aa"
+mongoose@^4.11.11:
+  version "4.11.11"
+  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-4.11.11.tgz#ae9baf860241e086c90b226fdda52f1afddc6a7b"
   dependencies:
     async "2.1.4"
     bson "~1.0.4"
     hooks-fixed "2.0.0"
     kareem "1.5.0"
-    mongodb "2.2.27"
+    mongodb "2.2.31"
     mpath "0.3.0"
     mpromise "0.5.5"
     mquery "2.3.1"


### PR DESCRIPTION
This PR is to refactor `@invisible/mongoose` module to export an instance of `mongoose`.